### PR TITLE
Fixed CI Spotless Check

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,32 +6,51 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Spotless check
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
+      - name: Checkout code
         uses: actions/checkout@v4.1.7
-      - name: Set up JDK
+
+      - name: Setup JDK
         uses: actions/setup-java@v4.2.2
         with:
           distribution: adopt
           java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          validate-wrappers: true
+          gradle-home-cache-cleanup: true
+
       - name: spotless
-        run: ./gradlew spotlessCheck
+        run: ./gradlew spotlessCheck  --no-daemon --no-configuration-cache
 
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
-      - name: Set up JDK
+      - name: Checkout code
+        uses: actions/checkout@v4.1.7
+
+      - name: Setup JDK
         uses: actions/setup-java@v4.2.2
         with:
           distribution: zulu
           java-version: 17
 
-      - uses: gradle/gradle-build-action@v3.5.0
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          validate-wrappers: true
+          gradle-home-cache-cleanup: true
+
       - name: Make Gradle executable
         run: chmod +x ./gradlew
 


### PR DESCRIPTION
### 🎯 Goal
One of the issues with Spotless is that it's not compatible with the Gradle configuration cache. To solve this we need to use --no-configuration-cache and --no-daemon flags

 [As reported here](https://github.com/diffplug/spotless/issues/1924)

### 🛠 Implementation details
Describe the implementation details for this Pull Request.

### ✍️ Explain examples
Explain examples with code for this updates.

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.